### PR TITLE
Allow to escalate match against erased

### DIFF
--- a/src/main/scala/sbt/LethalWarnings.scala
+++ b/src/main/scala/sbt/LethalWarnings.scala
@@ -10,6 +10,7 @@ object LethalWarnings {
 
   case object NonExhaustivePatternMatch extends LethalWarning("^match may not be exhaustive.*$")
   case object UniversalEquality extends LethalWarning("^comparing values of types \\S+ and \\S+ using \\S+ will always yield false")
+  case object MatchOnErased extends LethalWarning("^abstract type pattern \\S+ is unchecked since it is eliminated by erasure")
 
   val allWarnings = {
     import scala.reflect.runtime._

--- a/src/sbt-test/sbt-lethal-warnings/test-warnings/src/main/scala/FullOfWarnings.scala
+++ b/src/sbt-test/sbt-lethal-warnings/test-warnings/src/main/scala/FullOfWarnings.scala
@@ -10,4 +10,16 @@ object FullOfWarnings {
     }
   }
   val testUniversalEquality: Boolean = Some("foo") == "foo"
+
+  val testMatchOnErased = {
+    trait TraitWithDependantType {
+      type T
+    }
+
+    val test: TraitWithDependantType = null
+
+    test match {
+      case subject: test.T => ???
+    }
+  }
 }


### PR DESCRIPTION
This adds a case for `match { case subject: test.T => ??? }`: `abstract type pattern test.T is unchecked since it is eliminated by erasure`